### PR TITLE
Modifique test.sh para que ignore saltos de linea adicionales en la s…

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -72,6 +72,9 @@ function correr_pruebas {
             bash "${archivos_esperados[$(($ejercicio-1))]}" "$entrada" "$salida_obtenida" >> /dev/null
         fi
         
+        salida_sin_saltos_linea_finales=$(sed -E -z 's/\n+$//g' "$salida_obtenida")
+        echo "$salida_sin_saltos_linea_finales" > "$salida_obtenida"
+
         # Comparar la salida obtenida con la esperada
         if comparar_archivos "$salida_esperada" "$salida_obtenida"; then
             printf "Test $i: OK :)\n"


### PR DESCRIPTION
…alida de los acertijos

El comando diff, aun con la opcion -w, no ignora las diferencias en saltos de linea, por lo que debemos eliminarlos a mano. Noten que solo elimino los saltos de linea que estan al final del archivo, el resto se mantienen.